### PR TITLE
[Kiosk Rule] Adds floor price rule

### DIFF
--- a/kiosk/Move.toml
+++ b/kiosk/Move.toml
@@ -1,9 +1,10 @@
 [package]
 name = "Kiosk"
-version = "0.0.1"
+version = "0.0.2"
+published-at="0x434b5bd8f6a7b05fede0ff46c6e511d71ea326ed38056e3bcd681d2d7c2a7879"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "4c9993fa0" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "5b4da14" }
 
 [addresses]
-kiosk = "0x434b5bd8f6a7b05fede0ff46c6e511d71ea326ed38056e3bcd681d2d7c2a7879"
+kiosk = "0x0"

--- a/kiosk/sources/rules/floor_price_rule.move
+++ b/kiosk/sources/rules/floor_price_rule.move
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Description:
+/// This module defines a Rule which sets a minimum price of sale for items of type T.
+///
+/// Configuration:
+/// - min_price - the minimum sale price in MIST.
+///
+/// Use cases:
+/// - Defining a minimum price for all trades of type T.
+/// - Prevent trading of locked items with low pricing (e.g. by using purchase_cap).
+/// 
+module kiosk::floor_price_rule {
+    use sui::transfer_policy::{
+        Self as policy,
+        TransferPolicy,
+        TransferPolicyCap,
+        TransferRequest
+    };
+
+    /// The sale price was lower than the minimum amount.
+    const ESalePriceTooSmall: u64 = 0;
+
+    /// The "Rule" witness to authorize the policy.
+    struct Rule has drop {}
+
+    /// Configuration for the `Floor Price Rule`.
+    /// It holds the minimum price that an item can be sold at.
+    /// There can't be any sales with a price < than the min_price.
+    struct Config has store, drop {
+        min_price: u64
+    }
+
+    /// Creator action: Add the Floor Price Rule for the `T`.
+    /// Pass in the `TransferPolicy`, `TransferPolicyCap` and the `min_price`.
+    public fun add<T: key + store>(
+        policy: &mut TransferPolicy<T>,
+        cap: &TransferPolicyCap<T>,
+        min_price: u64
+    ) {
+        policy::add_rule(Rule {}, policy, cap, Config { min_price })
+    }
+
+    /// Buyer action: Checks that the sale amount is higher or equal to the min_amount.
+    public fun prove<T: key + store>(
+        policy: &mut TransferPolicy<T>,
+        request: &mut TransferRequest<T>
+    ) {
+        let config: &Config = policy::get_rule(Rule {}, policy);
+
+        assert!(policy::paid(request) >= config.min_price, ESalePriceTooSmall);
+        
+        policy::add_receipt(Rule {}, request)
+    }
+}

--- a/kiosk/tests/rules/floor_price_rule_tests.move
+++ b/kiosk/tests/rules/floor_price_rule_tests.move
@@ -1,0 +1,61 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module kiosk::floor_price_rule_tests {
+    use sui::tx_context::dummy as ctx;
+    use sui::transfer_policy as policy;
+    use sui::transfer_policy_tests as test;
+
+    use kiosk::floor_price_rule;
+
+    #[test]
+    fun test_floor_price_rule_default() {
+        let ctx = &mut ctx();
+        let (policy, cap) = test::prepare(ctx);
+
+        // Minimum sale price: 1 SUI.
+        floor_price_rule::add(&mut policy, &cap, 1_000_000_000);
+
+        let request = policy::new_request(test::fresh_id(ctx), 1_000_000_000, test::fresh_id(ctx));
+
+        floor_price_rule::prove(&mut policy, &mut request);
+        policy::confirm_request(&mut policy, request);
+
+        test::wrapup(policy, cap, ctx);
+    }
+
+    #[test]
+    fun test_floor_price_rule_high_price() {
+        let ctx = &mut ctx();
+        let (policy, cap) = test::prepare(ctx);
+
+        // Minimum sale price: 1 SUI.
+        floor_price_rule::add(&mut policy, &cap, 1_000_000_000);
+
+        let request = policy::new_request(test::fresh_id(ctx), 100_000_000_000, test::fresh_id(ctx));
+
+        floor_price_rule::prove(&mut policy, &mut request);
+        policy::confirm_request(&mut policy, request);
+
+        test::wrapup(policy, cap, ctx);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = floor_price_rule::ESalePriceTooSmall)]
+    fun fail_test_smaller_price() {
+        let ctx = &mut ctx();
+        let (policy, cap) = test::prepare(ctx);
+
+        // Minimum sale price: 1 SUI.
+        floor_price_rule::add(&mut policy, &cap, 1_000_000_000);
+
+        // Attemps a failed purchase with .99 SUI.
+        let request = policy::new_request(test::fresh_id(ctx), 999_999_999, test::fresh_id(ctx));
+
+        floor_price_rule::prove(&mut policy, &mut request);
+        policy::confirm_request(&mut policy, request);
+
+        test::wrapup(policy, cap, ctx);
+    }
+}


### PR DESCRIPTION
The PR adds a floor price rule to kiosk, to support minimum sale price set by the creator.

Also prepares the package for a package upgrade.