### PR TITLE
Quorum Upgrade Policy

### DIFF
--- a/upgrade_policy/quorum_upgrade/Move.toml
+++ b/upgrade_policy/quorum_upgrade/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Quorum Upgrade"
+version = "0.0.1"
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
+
+[addresses]
+quorum_upgrade_policy = "0x0"

--- a/upgrade_policy/quorum_upgrade/sources/quorum_upgrade_policy.move
+++ b/upgrade_policy/quorum_upgrade/sources/quorum_upgrade_policy.move
@@ -1,0 +1,420 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Simple upgrade policy that requires a `k` out of `n` quorum in order to perform
+/// a proposed upgrade.
+/// 
+/// This policy is created with a call to `quorum_upgrade_policy::new` providing
+/// the `UpgradeCap` of the package to be controlled by the policy, the `k` value 
+/// (number of votes, quorum to be reached for the upgrade to be allowed) and the list of
+/// `address`es allowed to vote. The `address`es provided will receive
+/// a `VotingCap` that allows them to vote for a proposed upgrade. 
+/// This policy can be created at any point in time during the lifetime of the original 
+/// package upgrade cap.
+/// The `QuorumUpgradeCap` received from the call to `quorum_upgrade_policy::new` will
+/// be used when proposing an upgrade and when authorizing that upgrade.
+/// Given that it is created with the original `UpgradeCap`, it is returned to the owner 
+/// of that capability, typically the publisher of the original package.
+/// That impies the owner of the `UpgradeCap` is the only one that can propose and
+/// authorize upgrades.
+/// Considering that the `QuorumUpgradeCap` is both `key` and `store` the owner can decide
+/// on alternative ways to offer that capability to other parties.
+/// As expected, however, the capability should be reasonably protected and secured.
+/// 
+/// An upgrade is proposed via `quorum_upgrade_policy::propose_upgrade` and saved as
+/// a shared object. As such it can be freely accessed. That instance will be used
+/// by both voters of the upgrade and the publisher of the upgrade.
+/// The proposer of an upgrade provides the digest of the upgrade that is saved with 
+/// the proposal. The idea is that the proposer will provide the compilable source code 
+/// to all voters, which in turn will verify the digest and, thus, the source code.
+/// 
+/// Voters can then vote for the upgrade via `quorum_upgrade_policy::vote` providing
+/// the `ProposedUpgrade` and their `VotingCap`. 
+/// 
+/// Once the quorum is reached the proposer can authorize the upgrade. An attempt to
+/// authourize an upgrade before the quorum is reached will fail.
+/// 
+/// Events are emitted to track the main operations on the proposal.
+/// A proposed upgrade lifetime is tracked via the 4 events:
+/// `UpgradeProposed`, `UpgradeVoted` and `UpgradePerformed` or `UpgradeDestroyed`.
+/// 
+/// Multiple upgrades can be live at the same time. That is not the expected behavior
+/// but there are no restrictions to the number of upgrades open at any point in time.
+/// When that happens the first upgrade executed "wins" and subsequent attempt to
+/// authorize an upgrade will fail as the version will not match any longer.
+/// 
+/// Notice:
+/// there are several upgrades to this policy that will be provided shortly and will
+/// help with the management of the policy:
+/// - the ability to restrict the upgrade as with normal packages (e.g. additive only, 
+/// dependency only or immutable) and whether to do that via voting or not is being
+/// discussed
+/// - the ability to transfer `VotingCap` instances to other addresses will likely
+/// be controlled by voting and it is an important feature to add
+/// - the ability to change the quorum (k) and the list of allowed voters (n) is
+/// under consideration
+/// - the creation and usage of a `Ballot` to vote for the upgrade is also being
+/// discussed. The ballot will be transferable and an easy way to relate to a proposal
+module quorum_upgrade_policy::quorum_upgrade_policy {
+    use std::vector;
+    use sui::event;
+    use sui::object::{Self, ID, UID};
+    use sui::package::{Self, UpgradeCap, UpgradeTicket, UpgradeReceipt};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+    use sui::vec_set::{Self, VecSet};
+
+    /// The capability controlling the upgrade. 
+    /// Initialized with `new` is returned to the caller to be stored as desired.
+    /// From this point on every upgrade is performed via this policy.
+    struct QuorumUpgradeCap has key, store {
+        id: UID,
+        /// Upgrade cap of the package controlled by this policy.
+        upgrade_cap: UpgradeCap,
+        /// Number of votes (quorum) required for the upgrade to be allowed.
+        required_votes: u64,
+        /// Allowed voters.
+        voters: VecSet<address>,
+        /// Voting caps issued.
+        voter_caps: VecSet<ID>,
+    }
+
+    /// Capability to vote an upgrade.
+    /// Sent to each registered address when a new upgrade is created.
+    /// Receiving parties will use the capability to vote for the upgrade. 
+    struct VotingCap has key {
+        id: UID,
+        /// The original address the capability was sent to.
+        owner: address,
+        /// The ID of the `QuorumUpgradeCap` this capability refers to.
+        upgrade_cap: ID,
+        /// The count of transfers this capability went through. 
+        /// It is informational only and can be used to track transfers of
+        /// voter capability instances.
+        transfers_count: u64,
+        /// The number of votes issued by this voter.
+        votes_issued: u64,
+    }
+
+    /// A proposed upgrade that is going through voting.
+    /// `ProposedUpgrade` instances are shared objects that will be passed as 
+    /// an argument, together with a `VotingCap`, when voting.
+    /// It's possible to have multiple proposed upgrades at the same time and 
+    /// the first successful upgrade will obsolete all the others, given
+    /// an attempt to upgrade with a "concurrent" one will fail because of
+    /// versioning.
+    struct ProposedUpgrade has key {
+        id: UID,
+        /// The ID of the `QuorumUpgradeCap` that this vote was initiated from.
+        upgrade_cap: ID,
+        /// The address requesting permission to perform the upgrade.
+        /// This is the sender of the transaction that proposes and 
+        /// performs the upgrade.
+        proposer: address,
+        /// The digest of the bytecode that the package will be upgraded to.
+        digest: vector<u8>,
+        /// The current voters that have accepted the upgrade.
+        current_voters: VecSet<ID>,
+    }
+
+    // 
+    // Events to track history and progress of upgrades
+    //
+
+    /// A new proposal for an upgrade.
+    struct UpgradeProposed has copy, drop {
+        /// The instance of the quorum upgrade policy.
+        upgrade_cap: ID,
+        /// The ID of the proposal (`ProposedUpgrade` instance).
+        proposal: ID,
+        /// Digest of the proposal.
+        digest: vector<u8>,
+        /// The address (sender) of the proposal.
+        proposer: address,
+        /// Allowed voters.
+        voters: VecSet<address>,
+    }
+
+    /// A given proposal was voted.
+    struct UpgradeVoted has copy, drop {
+        /// The ID of the proposal (`ProposedUpgrade` instance).
+        proposal: ID,
+        /// Digest of the proposal.
+        digest: vector<u8>,
+        /// The ID of the voter (VotingCap instance).
+        voter: ID,
+        /// The signer of the transaction that voted.
+        signer: address,
+    }
+
+    /// A succesful upgrade.
+    struct UpgradePerformed has copy, drop {
+        /// The instance of the quorum upgrade policy.
+        upgrade_cap: ID,
+        /// the ID of the proposal (`ProposedUpgrade` instance).
+        proposal: ID,
+        /// digest of the proposal.
+        digest: vector<u8>,
+        /// proposer of the upgrade.
+        proposer: address,
+    }
+
+    /// A proposal is destroyed.
+    struct UpgradeDestroyed has copy, drop {
+        /// The instance of the quorum upgrade policy.
+        upgrade_cap: ID,
+        /// The ID of the proposal (`ProposedUpgrade` instance).
+        proposal: ID,
+        /// Digest of the proposal.
+        digest: vector<u8>,
+        /// Proposer of the upgrade.
+        proposer: address,
+    }
+
+    /// Allowed voters must in the [1, 100] range.
+    const EAllowedVotersError: u64 = 0;
+    /// Required votes must be less than allowed voters.
+    const ERequiredVotesError: u64 = 1;
+    /// An upgrade was issued already, and the operation requested failed.
+    const EAlreadyIssued: u64 = 2;
+    /// The given `VotingCap` is not for the given `ProposedUpgrade`
+    const EInvalidVoterForUpgrade: u64 = 3;
+    /// The given capability owner already voted.
+    const EAlreadyVoted: u64 = 4;
+    /// Not enough votes to perform the upgrade.
+    const ENotEnoughVotes: u64 = 5;
+    /// The operation required the signer to be the same as the upgrade proposer.
+    const ESignerMismatch: u64 = 6;
+    /// Proposal (`QuorumUpgradeCap`) and upgrade (`ProposedUpgrade`) do not match.
+    const EInvalidProposalForUpgrade: u64 = 7;
+
+    /// Create a `QuorumUpgradeCap` given an `UpgradeCap`.
+    /// The returned instance is the only and exclusive controller of upgrades. 
+    /// The `k` (`required_votes`) out of `n` (length of `voters`) is set up
+    /// at construction time and it is immutable.
+    /// The `voters` will receive a `VotingCap` that allows them to vote.
+    public fun new(
+        upgrade_cap: UpgradeCap,
+        required_votes: u64,
+        voters: VecSet<address>,
+        ctx: &mut TxContext,
+    ): QuorumUpgradeCap {
+        // currently the allowed voters is limited to 100 and the number of
+        // required votes must be bigger than 0 and less or equal than the number of voters
+        assert!(vec_set::size(&voters) > 0, EAllowedVotersError);
+        assert!(vec_set::size(&voters) <= 100, EAllowedVotersError);
+        assert!(required_votes > 0, ERequiredVotesError);
+        assert!(required_votes <= vec_set::size(&voters), ERequiredVotesError);
+
+        // upgrade cap id
+        let cap_uid = object::new(ctx);
+        let cap_id = object::uid_to_inner(&cap_uid);
+
+        let voter_caps: VecSet<ID> = vec_set::empty();
+        let voter_addresses = vec_set::keys(&voters);
+        let voter_idx = vector::length(voter_addresses);
+        while (voter_idx > 0) {
+            voter_idx = voter_idx - 1;
+            let address = *vector::borrow(voter_addresses, voter_idx);
+            let voter_uid = object::new(ctx);
+            let voter_id = object::uid_to_inner(&voter_uid);
+            transfer::transfer(
+                VotingCap {
+                    id: voter_uid,
+                    owner: address,
+                    upgrade_cap: cap_id,
+                    transfers_count: 0,
+                    votes_issued: 0,
+                },
+                address,
+            );
+            vec_set::insert(&mut voter_caps, voter_id);
+        };
+
+        QuorumUpgradeCap {
+            id: cap_uid,
+            upgrade_cap,
+            required_votes,
+            voters,
+            voter_caps,
+        }
+    }
+
+    /// Propose an upgrade. 
+    /// The `digest` of the proposed upgrade is provided to identify the upgrade.
+    /// The proposer is the sender of the transaction and must be the signer
+    /// of the commit transaction as well.
+    public fun propose_upgrade(
+        cap: &QuorumUpgradeCap,
+        digest: vector<u8>,
+        ctx: &mut TxContext,
+    ) {
+        let cap_id = object::id(cap);
+        let proposal_uid = object::new(ctx);
+        let proposal_id = object::uid_to_inner(&proposal_uid);
+        
+        let proposer = tx_context::sender(ctx);
+        
+        event::emit(UpgradeProposed {
+            upgrade_cap: cap_id,
+            proposal: proposal_id,
+            digest,
+            proposer,
+            voters: cap.voters,
+        });
+
+        transfer::share_object(ProposedUpgrade {
+            id: proposal_uid,
+            upgrade_cap: cap_id,
+            proposer,
+            digest,
+            current_voters: vec_set::empty(),
+        })
+    }
+
+    /// Vote in favor of an upgrade, aborts if the voter is not for the proposed
+    /// upgrade or if they voted already, or if the upgrade was already performed.
+    public fun vote(
+        proposal: &mut ProposedUpgrade, 
+        voter: &mut VotingCap,
+        ctx: &TxContext,
+    ) {
+        assert!(proposal.proposer != @0x0, EAlreadyIssued);
+        assert!(proposal.upgrade_cap == voter.upgrade_cap, EInvalidVoterForUpgrade);
+        let voter_id = object::id(voter);
+        assert!(
+            !vec_set::contains(&proposal.current_voters, &voter_id), 
+            EAlreadyVoted,
+        );
+        vec_set::insert(&mut proposal.current_voters, voter_id);
+        voter.votes_issued = voter.votes_issued + 1;
+
+        event::emit(UpgradeVoted {
+            proposal: object::id(proposal),
+            digest: proposal.digest,
+            voter: voter_id,
+            signer: tx_context::sender(ctx),
+        });
+    }
+
+    /// Issue an `UpgradeTicket` for the upgrade being voted on. Aborts if 
+    /// there are not enough votes yet, or if the upgrade was already performed.
+    /// The signer of the transaction must be the same as the one proposing the
+    /// upgrade.
+    public fun authorize_upgrade(
+        cap: &mut QuorumUpgradeCap,
+        proposal: &mut ProposedUpgrade, 
+        ctx: &TxContext,
+    ): UpgradeTicket {
+        assert!(proposal.upgrade_cap == object::id(cap), EInvalidProposalForUpgrade);
+        assert!(
+            vec_set::size(&proposal.current_voters) >= cap.required_votes, 
+            ENotEnoughVotes,
+        );
+        assert!(proposal.proposer != @0x0, EAlreadyIssued);
+
+        // assert the signer is the proposer and the upgrade has not happened yet
+        let signer = tx_context::sender(ctx);
+        assert!(proposal.proposer == signer, ESignerMismatch);
+        proposal.proposer = @0x0;
+
+        event::emit(UpgradePerformed {
+            upgrade_cap: proposal.upgrade_cap,
+            proposal: object::id(proposal),
+            digest: proposal.digest,
+            proposer: signer,
+        });
+
+        let policy = package::upgrade_policy(&cap.upgrade_cap);
+        package::authorize_upgrade(
+            &mut cap.upgrade_cap,
+            policy,
+            proposal.digest,
+        )
+    }
+
+    /// Finalize the upgrade to produce the given receipt.
+    public fun commit_upgrade(
+        cap: &mut QuorumUpgradeCap, 
+        receipt: UpgradeReceipt,
+    ) {
+        package::commit_upgrade(&mut cap.upgrade_cap, receipt)
+    }
+
+    /// Destroy (and so discard) an existing proposed upgrade.
+    /// The signer of the transaction must be the same address that proposed the
+    /// upgrade.
+    public fun destroy_proposed_upgrade(proposed_upgrade: ProposedUpgrade, ctx: &TxContext) {
+        let proposal = object::id(&proposed_upgrade);
+        let ProposedUpgrade {
+            id,
+            upgrade_cap,
+            proposer,
+            digest,
+            current_voters: _,
+        } = proposed_upgrade;
+        assert!(proposer == tx_context::sender(ctx), ESignerMismatch);
+        event::emit(UpgradeDestroyed {
+            upgrade_cap,
+            proposal,
+            digest,
+            proposer,
+        });
+        object::delete(id);
+    }
+
+    //
+    // Accessors
+    //
+
+    /// Get the `UpgradeCap` of the package protected by the policy.
+    public fun upgrade_cap(cap: &QuorumUpgradeCap): &UpgradeCap {
+        &cap.upgrade_cap
+    }
+
+    /// Get the number of required votes for an upgrade to be valid.
+    public fun required_votes(cap: &QuorumUpgradeCap): u64 {
+        cap.required_votes
+    }
+
+    /// Get the allowed voters for the policy.
+    public fun voters(cap: &QuorumUpgradeCap): &VecSet<address> {
+        &cap.voters
+    }
+
+    /// Get the ID of the policy associated to the proposal.
+    public fun proposal_for(proposal: &ProposedUpgrade): ID {
+        proposal.upgrade_cap
+    }
+
+    /// Get the upgrade proposer. 
+    public fun proposer(proposal: &ProposedUpgrade): address {
+        proposal.proposer
+    }
+
+    /// Get the digest of the proposed upgrade.
+    public fun digest(proposal: &ProposedUpgrade): &vector<u8> {
+        &proposal.digest
+    }
+
+    /// Get the current accepted votes for the given proposal.
+    public fun current_voters(proposal: &ProposedUpgrade): &VecSet<ID> {
+        &proposal.current_voters
+    }
+
+    #[test_only]
+    /// Make the package immutable by destroying the quorum upgrade cap and the
+    /// underlying upgrade cap.
+    public fun make_immutable(cap: QuorumUpgradeCap) {
+        let QuorumUpgradeCap {
+            id,
+            upgrade_cap,
+            required_votes: _,
+            voters: _,
+            voter_caps: _,
+        } = cap;
+        object::delete(id);
+        package::make_immutable(upgrade_cap);
+    }
+
+}

--- a/upgrade_policy/quorum_upgrade/tests/quorum_upgrade_policy_test.move
+++ b/upgrade_policy/quorum_upgrade/tests/quorum_upgrade_policy_test.move
@@ -1,0 +1,419 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module quorum_upgrade_policy::quorum_upgrade_policy_test {
+    use quorum_upgrade_policy::quorum_upgrade_policy::{Self, QuorumUpgradeCap, ProposedUpgrade, VotingCap};
+    use sui::address::from_u256;
+    use sui::object::id_from_address as id;
+    use sui::package;
+    use sui::vec_set::{Self, VecSet};
+    use sui::test_scenario::{Self as test, Scenario, ctx};
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::ERequiredVotesError)]
+    fun quorum_upgrade_too_many_required_votes() {
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(30, 5, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::EAllowedVotersError)]
+    fun quorum_upgrade_too_many_voters() {
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(80, 101, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::EAllowedVotersError)]
+    fun quorum_upgrade_too_few_voters() {
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(1, 0, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::ERequiredVotesError)]
+    fun quorum_upgrade_too_few_required_votes() {
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(0, 10, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+    }
+
+    #[test]
+    fun quorum_upgrade_voters_ok() {
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(80, 80, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(100, 100, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(2, 2, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(70, 100, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(30, 50, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(1, 2, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+    }
+
+    #[test]
+    fun quorum_upgrade_propose_upgrade_ok() {
+        let test = test::begin(@0x1);
+        let digest: vector<u8> = x"0123456789";
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+
+        test::next_tx(&mut test, @0x1);
+        quorum_upgrade_policy::propose_upgrade(&quorum_upgrade_cap, digest, ctx(&mut test));
+
+        test::next_tx(&mut test, @0x1);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::EInvalidProposalForUpgrade)]
+    fun quorum_upgrade_authorize_upgrade_bad_cap() {
+        let test = test::begin(@0x1);
+        let digest: vector<u8> = x"0123456789";
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+
+        test::next_tx(&mut test, @0x1);
+        quorum_upgrade_policy::propose_upgrade(&quorum_upgrade_cap, digest, ctx(&mut test));
+
+        test::next_tx(&mut test, @0x1);
+        let quorum_upgrade_cap1 = get_quorum_upgrade_cap(6, 10, &mut test);
+        let proposal = test::take_shared<ProposedUpgrade>(&test);
+        let ticket = quorum_upgrade_policy::authorize_upgrade(
+            &mut quorum_upgrade_cap1, 
+            &mut proposal, 
+            ctx(&mut test),
+        );
+        let receipt = package::test_upgrade(ticket);
+        quorum_upgrade_policy::commit_upgrade(&mut quorum_upgrade_cap, receipt);
+        test::return_shared(proposal);
+
+        test::next_tx(&mut test, @0x1);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap1);
+
+        end_partial_test(quorum_upgrade_cap, test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::ENotEnoughVotes)]
+    fun quorum_upgrade_authorize_upgrade_not_enough_votes() {
+        let digest: vector<u8> = x"0123456789";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+        perform_upgrade(@0x1, &mut quorum_upgrade_cap, &mut test);
+        end_partial_test(quorum_upgrade_cap, test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::ENotEnoughVotes)]
+    fun quorum_upgrade_authorize_upgrade_not_enough_votes_1() {
+        let digest: vector<u8> = x"0123456789";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+        vote(@0x100, &mut test);
+        perform_upgrade(@0x1, &mut quorum_upgrade_cap, &mut test);
+        end_partial_test(quorum_upgrade_cap, test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::ENotEnoughVotes)]
+    fun quorum_upgrade_authorize_upgrade_not_enough_votes_2() {
+        let digest: vector<u8> = x"0123456789";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(2, 2, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+        vote(@0x100, &mut test);
+        perform_upgrade(@0x1, &mut quorum_upgrade_cap, &mut test);
+        end_partial_test(quorum_upgrade_cap, test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::ENotEnoughVotes)]
+    fun quorum_upgrade_authorize_upgrade_not_enough_votes_3() {
+        let digest: vector<u8> = x"0123456789";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(6, 10, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+        vote(@0x100, &mut test);
+        vote(@0x101, &mut test);
+        vote(@0x105, &mut test);
+        vote(@0x106, &mut test);
+        vote(@0x102, &mut test);
+        perform_upgrade(@0x1, &mut quorum_upgrade_cap, &mut test);
+        end_partial_test(quorum_upgrade_cap, test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::ESignerMismatch)]
+    fun quorum_upgrade_authorize_upgrade_bad_signer() {
+        let digest: vector<u8> = x"0123456789";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+        let quorum_upgrade_cap_1 = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x2, &quorum_upgrade_cap_1, digest, &mut test);
+
+        vote(@0x100, &mut test);
+        vote(@0x103, &mut test);
+        vote(@0x101, &mut test);
+        vote(@0x102, &mut test);
+
+        perform_upgrade(@0x1, &mut quorum_upgrade_cap_1, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap_1);
+        end_partial_test(quorum_upgrade_cap, test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::EInvalidProposalForUpgrade)]
+    fun quorum_upgrade_authorize_upgrade_bad_voter_cap() {
+        let digest: vector<u8> = x"0123456789";
+        let digest1: vector<u8> = x"9876543210";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+        let quorum_upgrade_cap_1 = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x2, &quorum_upgrade_cap_1, digest1, &mut test);
+
+        vote(@0x102, &mut test);
+        vote(@0x103, &mut test);
+        vote(@0x101, &mut test);
+
+        perform_upgrade(@0x2, &mut quorum_upgrade_cap, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap_1);
+        end_partial_test(quorum_upgrade_cap, test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::EAlreadyIssued)]
+    fun quorum_upgrade_authorize_upgrade_already_issued() {
+        let digest: vector<u8> = x"0123456789";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+
+        vote(@0x100, &mut test);
+        vote(@0x103, &mut test);
+        vote(@0x104, &mut test);
+
+        perform_upgrade(@0x1, &mut quorum_upgrade_cap, &mut test);
+        perform_upgrade(@0x1, &mut quorum_upgrade_cap, &mut test);
+        end_partial_test(quorum_upgrade_cap, test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::EAlreadyIssued)]
+    fun quorum_upgrade_vote_already_issued() {
+        let digest: vector<u8> = x"0123456789";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+
+        vote(@0x100, &mut test);
+        vote(@0x103, &mut test);
+        vote(@0x104, &mut test);
+
+        perform_upgrade(@0x1, &mut quorum_upgrade_cap, &mut test);
+        vote(@0x101, &mut test);
+        end_partial_test(quorum_upgrade_cap, test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::EInvalidVoterForUpgrade)]
+    fun quorum_upgrade_bad_voter() {
+        let digest: vector<u8> = x"0123456789";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        test::next_tx(&mut test, @0x100);
+        // get the voter cap and use it over the next upgrade and proposal
+        let voter_cap = test::take_from_address<VotingCap>(&test, @0x100);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+        test::next_tx(&mut test, @0x100);
+        let proposal = test::take_shared<ProposedUpgrade>(&test);
+        quorum_upgrade_policy::vote(&mut proposal, &mut voter_cap, ctx(&mut test));
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::return_shared(proposal);
+        test::return_to_address(@0x100, voter_cap);
+        test::end(test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::EAlreadyVoted)]
+    fun quorum_upgrade_vote_twice() {
+        let digest: vector<u8> = x"0123456789";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+
+        vote(@0x100, &mut test);
+        vote(@0x100, &mut test);
+
+        end_partial_test(quorum_upgrade_cap, test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = quorum_upgrade_policy::quorum_upgrade_policy::EAlreadyIssued)]
+    fun quorum_upgrade_upgrade_already_issued() {
+        let digest: vector<u8> = x"0123456789";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+        vote(@0x100, &mut test);
+        vote(@0x101, &mut test);
+        vote(@0x104, &mut test);
+        perform_upgrade(@0x1, &mut quorum_upgrade_cap, &mut test);
+        vote(@0x102, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+    }
+
+    #[test]
+    fun quorum_upgrade_perform_upgrade_ok() {
+        let digest: vector<u8> = x"0123456789";
+
+        let test = test::begin(@0x1);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+        vote(@0x100, &mut test);
+        vote(@0x101, &mut test);
+        vote(@0x104, &mut test);
+        perform_upgrade(@0x1, &mut quorum_upgrade_cap, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+
+        let test = test::begin(@0x2);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(8, 10, &mut test);
+        propose_upgrade(@0x2, &quorum_upgrade_cap, digest, &mut test);
+        vote(@0x100, &mut test);
+        vote(@0x101, &mut test);
+        vote(@0x104, &mut test);
+        vote(@0x105, &mut test);
+        vote(@0x106, &mut test);
+        vote(@0x107, &mut test);
+        vote(@0x108, &mut test);
+        vote(@0x109, &mut test);
+        perform_upgrade(@0x2, &mut quorum_upgrade_cap, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+
+        let test = test::begin(@0x3);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 9, &mut test);
+        propose_upgrade(@0x3, &quorum_upgrade_cap, digest, &mut test);
+        vote(@0x100, &mut test);
+        vote(@0x101, &mut test);
+        vote(@0x104, &mut test);
+        vote(@0x105, &mut test);
+        perform_upgrade(@0x3, &mut quorum_upgrade_cap, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+
+        let test = test::begin(@0x4);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(1, 100, &mut test);
+        propose_upgrade(@0x4, &quorum_upgrade_cap, digest, &mut test);
+        vote(@0x140, &mut test);
+        perform_upgrade(@0x4, &mut quorum_upgrade_cap, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+
+        let test = test::begin(@0x5);
+        let quorum_upgrade_cap = get_quorum_upgrade_cap(3, 5, &mut test);
+        propose_upgrade(@0x1, &quorum_upgrade_cap, digest, &mut test);
+        vote(@0x103, &mut test); 
+        vote(@0x100, &mut test); 
+        vote(@0x102, &mut test); 
+        vote(@0x101, &mut test);
+        vote(@0x104, &mut test);
+        perform_upgrade(@0x1, &mut quorum_upgrade_cap, &mut test);
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+    }
+
+    fun get_quorum_upgrade_cap(
+        required_vote: u64, 
+        voter_count: u256,
+        test: &mut Scenario,
+    ): QuorumUpgradeCap {
+        let cap = package::test_publish(id(@0x42), ctx(test));
+        let voters = get_voters(voter_count, 0x100);
+        quorum_upgrade_policy::new(cap, required_vote, voters, ctx(test))
+    }
+
+    fun get_voters(count: u256, voter: u256): VecSet<address> {
+        let voters = vec_set::empty();
+        while (voter < 0x100u256 + count) {
+            vec_set::insert(&mut voters, from_u256(voter));
+            voter = voter + 1;
+        };
+        voters
+    }
+
+    fun vote(voter: address, test: &mut Scenario) {
+        test::next_tx(test, voter);
+        let voter_cap = test::take_from_address<VotingCap>(test, voter);
+        let proposal = test::take_shared<ProposedUpgrade>(test);
+        quorum_upgrade_policy::vote(&mut proposal, &mut voter_cap, ctx(test));
+        test::return_to_address(voter, voter_cap);
+        test::return_shared(proposal);
+    }
+
+    fun propose_upgrade(
+        sender: address, 
+        quorum_upgrade_cap: &QuorumUpgradeCap, 
+        digest: vector<u8>,
+        test: &mut Scenario,
+    ) {
+        test::next_tx(test, sender);
+        quorum_upgrade_policy::propose_upgrade(quorum_upgrade_cap, digest, ctx(test));
+    }
+
+    fun perform_upgrade(
+        sender: address, 
+        quorum_upgrade_cap: &mut QuorumUpgradeCap, 
+        test: &mut Scenario,
+    ) {
+        test::next_tx(test, sender);
+        let proposal = test::take_shared<ProposedUpgrade>(test);
+        let ticket = quorum_upgrade_policy::authorize_upgrade(
+            quorum_upgrade_cap, 
+            &mut proposal, 
+            ctx(test),
+        );
+        let receipt = package::test_upgrade(ticket);
+        quorum_upgrade_policy::commit_upgrade(quorum_upgrade_cap, receipt);
+        test::return_shared(proposal);
+    }
+
+    fun end_partial_test(quorum_upgrade_cap: QuorumUpgradeCap, test: Scenario) {
+        test::next_tx(&mut test, @0x1);
+        let proposal = test::take_shared<ProposedUpgrade>(&test);
+        quorum_upgrade_policy::destroy_proposed_upgrade(proposal, ctx(&mut test));
+        quorum_upgrade_policy::make_immutable(quorum_upgrade_cap);
+        test::end(test);
+    }
+}


### PR DESCRIPTION
Implementation of a k out of n policy for package upgrade (quorum upgrade policy).
This is the simple solutions we talked about and we plan to go out with.
Docs/tests should be decent enough for an understanding but much more is coming.
What this does is along the following lines:
* An owner of an UpgradeCap can wrap it into this policy which will allow for given "entities" to vote on upgrades.
* Registered addresses get a VotingCap which is used to vote for proposed upgrades.
* The signer performing the upgrade must be the same as the proposer of the upgrade
* Multiple upgrade can be up at the same time and first committed wins (as expected)
