### PR TITLE
[ZkSend] Migrate to move 2024, enable tests

### DIFF
--- a/zksend/zk_bag/Move.toml
+++ b/zksend/zk_bag/Move.toml
@@ -3,6 +3,7 @@ name = "zk_bag"
 version = "1.0.0"
 # mainnet published-at
 published-at="0x5bb7d0bb3240011336ca9015f553b2646302a4f05f821160344e9ec5a988f740"
+edition = "2024.beta"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }

--- a/zksend/zk_bag/sources/zk_bag.move
+++ b/zksend/zk_bag/sources/zk_bag.move
@@ -1,21 +1,21 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// ZkBag is a contract to allow transfering objects (up to a fixed limit)
+/// ZkBag is a contract to allow transfering of objects (up to a fixed limit)
 /// through zksend. This contract allows for:
 /// 1. Claiming in an all-or-nothing fashion from the ephemeral address
-/// 2. Allowing the owner to reclaim the items (helpful because we don't store the ephemeral private keys)
-/// 3. Keeping costs low using TTO.
-/// 4. Allows re-assignment to a new address by the owner of the bag.
+/// 2. Allowing the owner to reclaim the contents
+/// 3. Keeping costs low using TTO (~10x compared to DOFs).
+/// 4. Allows re-assignment to a new address by the owner of the bag (link regeneration)
 module zk_bag::zk_bag {
-    use sui::object::{Self, UID, ID};
-    use sui::tx_context::{TxContext, sender};
-    use sui::transfer::{Self, Receiving};
-    use sui::table::{Self, Table};
-    use sui::vec_set::{Self, VecSet};
+    use sui::{
+        transfer::{Receiving},
+        table::{Self, Table},
+        vec_set::{Self, VecSet}
+    };
 
     /// Capping this at 50 items as a limit based on business requirements.
-    /// WARNING: DO NOT EXCEED THE MAXIMUM INPUT IN A PTB LIMIT, 
+    /// WARNING: DO NOT EXCEED THE MAXIMUM INPUTs IN A PTB LIMIT, 
     /// AS THE CONTRACT WILL BECOME UNUSABLE.
     const MAX_ITEMS: u64 = 50;
 
@@ -40,18 +40,18 @@ module zk_bag::zk_bag {
     ///
     /// We can keep a unique address -> bag map, considering
     /// that addresses are ephemeral. They'll be randomly generated and be used once.
-    struct BagStore has key {
+    public struct BagStore has key {
         id: UID,
         items: Table<address, ZkBag>
     }
 
     /// A hot-potato to make sure that the bag is emptied in one PTB.
-    struct BagClaim {
+    public struct BagClaim {
         bag_id: ID
     }
 
     /// The bag that holds the owner, the receiver, and the items.
-    struct ZkBag has key, store {
+    public struct ZkBag has key, store {
         id: UID,
         owner: address,
         item_ids: VecSet<address>
@@ -67,27 +67,30 @@ module zk_bag::zk_bag {
 
     /// Creates a new bag for a receiver address. Aborts if one already exists.
     public fun new(store: &mut BagStore, receiver: address, ctx: &mut TxContext) {
-        assert!(!table::contains(&store.items, receiver), EClaimAddressAlreadyExists);
+        assert!(!store.items.contains(receiver), EClaimAddressAlreadyExists);
 
-        table::add(&mut store.items, receiver, ZkBag {
+        store.items.add(receiver, ZkBag {
             id: object::new(ctx),
-            owner: sender(ctx),
+            owner: ctx.sender(),
             item_ids: vec_set::empty()
-        })
+        });
+
     }
 
     /// Adds an item of type `T` to the bag.
     /// The owner can add items here even after sharing, but most of the use cases
     /// wouldn't involve this flow.
     public fun add<T: key + store>(store: &mut BagStore, receiver: address, item: T, ctx: &mut TxContext) {
-        assert!(table::contains(&store.items, receiver), EClaimAddressNotExists);
-        let bag = table::borrow_mut(&mut store.items, receiver);
+        assert!(store.items.contains(receiver), EClaimAddressNotExists);
 
-        assert!(bag.owner == sender(ctx), EUnauthorized);
+        let bag = store.items.borrow_mut(receiver);
 
-        assert!(vec_set::size(&bag.item_ids) < MAX_ITEMS, ETooManyItems);
+        assert!(bag.owner == ctx.sender(), EUnauthorized);
+
+        assert!(bag.item_ids.size() < MAX_ITEMS, ETooManyItems);
+
         // we save the list of IDS so that we can strictly-check that we've removed all items in a single-go.
-        vec_set::insert(&mut bag.item_ids, object::id_address(&item));
+        bag.item_ids.insert(object::id_address(&item));
 
         // TTO (Transfer to Object) the item to the bag.
         transfer::public_transfer(item, object::id_address(bag));
@@ -95,10 +98,10 @@ module zk_bag::zk_bag {
 
     /// Starts a claim flow as the receiver.
     public fun init_claim(store: &mut BagStore, ctx: &mut TxContext): (ZkBag, BagClaim) {
-        let receiver = sender(ctx);
+        let receiver = ctx.sender();
 
-        assert!(table::contains(&store.items, receiver), EClaimAddressNotExists);
-        let bag = table::remove(&mut store.items, receiver);
+        assert!(store.items.contains(receiver), EClaimAddressNotExists);
+        let bag = store.items.remove(receiver);
 
         let claim_proof = BagClaim {
             bag_id: object::id(&bag)
@@ -109,13 +112,13 @@ module zk_bag::zk_bag {
 
     /// Starts a re-claim flow as the creator of the bag.
     public fun reclaim(store: &mut BagStore, receiver: address, ctx: &mut TxContext): (ZkBag, BagClaim) {
-        assert!(table::contains(&store.items, receiver), EClaimAddressNotExists);
-        let bag = table::remove(&mut store.items, receiver);
+        assert!(store.items.contains(receiver), EClaimAddressNotExists);
+        let bag = store.items.remove(receiver);
 
-        assert!(bag.owner == sender(ctx), EUnauthorized);
+        assert!(bag.owner == ctx.sender(), EUnauthorized);
 
         let claim_proof = BagClaim {
-            bag_id: object::id(&bag)
+            bag_id: bag.id.to_inner()
         };
 
         (bag, claim_proof)
@@ -123,36 +126,37 @@ module zk_bag::zk_bag {
 
     /// Allows switching the receiver address of the bag.
     public fun update_receiver(store: &mut BagStore, from: address, to: address, ctx: &mut TxContext) {
-        assert!(table::contains(&store.items, from), EClaimAddressNotExists);
-        assert!(!table::contains(&store.items, to), EClaimAddressAlreadyExists);
+        assert!(store.items.contains(from), EClaimAddressNotExists);
+        assert!(!store.items.contains(to), EClaimAddressAlreadyExists);
 
-        let bag = table::remove(&mut store.items, from);
+        let bag = store.items.remove(from);
         // validate that the sender is the owner of the bag.
-        assert!(bag.owner == sender(ctx), EUnauthorized);
-        table::add(&mut store.items, to, bag);
+        assert!(bag.owner == ctx.sender(), EUnauthorized);
+
+        store.items.add(to, bag);
     }
 
     /// Claim an item from the bag.
-    /// Run N of these in a PTB to claim all items.
+    /// Run N of these in a PTB to claim all items. This works in an all-or-nothing way.
     public fun claim<T: key + store>(bag: &mut ZkBag, claim: &BagClaim, receiving: Receiving<T>): T {
-        assert!(is_valid_claim_object(bag, claim), EUnauthorizedProof);
+        assert!(bag.is_valid_claim_object(claim), EUnauthorizedProof);
 
         let item = transfer::public_receive(&mut bag.id, receiving);
 
         // We only claim items the owner explicitly added here (transfered through `add` of this module).
-        // Protects us from claiming "spam" objects anyone could TTO to the bag.
-        assert!(vec_set::contains(&bag.item_ids, &object::id_address(&item)), EItemNotExists);
+        // Protects us from reducing the count when the item was never explicitly added, or to prevent claiming
+        // "spam" objects.
+        assert!(bag.item_ids.contains(&object::id_address(&item)), EItemNotExists);
 
-        vec_set::remove(&mut bag.item_ids, &object::id_address(&item));
+        bag.item_ids.remove(&object::id_address(&item));
 
         item
     }
 
-    /// Finalize this + destroy the bag to get storage rebates.
-    /// Can only be finalized when we've claimed all items from the bag.
+    /// finalize this + destroy the bag to get storage rebates.
     public fun finalize(bag: ZkBag, claim: BagClaim) {
-        assert!(is_valid_claim_object(&bag, &claim), EUnauthorizedProof);
-        assert!(vec_set::is_empty(&bag.item_ids), EBagNotEmpty);
+        assert!(bag.is_valid_claim_object(&claim), EUnauthorizedProof);
+        assert!(bag.item_ids.is_empty(), EBagNotEmpty);
 
         let BagClaim { bag_id: _  } = claim;
 
@@ -162,12 +166,12 @@ module zk_bag::zk_bag {
             item_ids: _
         } = bag;
 
-        object::delete(id);
+        id.delete();
     }
 
     /// Validate that a bag can be claimed using this BagClaim object.
     fun is_valid_claim_object(bag: &ZkBag, claim: &BagClaim): bool {
-        claim.bag_id == object::id(bag)
+        claim.bag_id == bag.id.as_inner()
     }
 
     #[test_only]

--- a/zksend/zk_bag/sources/zk_bag.move
+++ b/zksend/zk_bag/sources/zk_bag.move
@@ -36,7 +36,6 @@ module zk_bag::zk_bag {
 
     /// A store that holds all the bags to prevent needing
     /// the objectId in the URL of requests.
-    /// Adds a throughput limit of 200TPS to the system.
     ///
     /// We can keep a unique address -> bag map, considering
     /// that addresses are ephemeral. They'll be randomly generated and be used once.

--- a/zksend/zk_bag/tests/zk_bag_tests.move
+++ b/zksend/zk_bag/tests/zk_bag_tests.move
@@ -2,17 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module zk_bag::zk_bag_tests {
-
-    use std::vector;
-
-    use sui::tx_context::TxContext;
-    use sui::object::{UID, Self};
-
-    use sui::test_scenario::{Self as ts, ctx, Scenario};
+    use sui::test_scenario::{Self as ts, Scenario};
 
     use zk_bag::zk_bag::{Self, BagStore};
 
-    struct TestItem has key, store {
+    public struct TestItem has key, store {
         id: UID
     }
 
@@ -21,37 +15,35 @@ module zk_bag::zk_bag_tests {
     const USER_THREE: address = @0x3;
 
     // TODO: Fix this when Receiving tests are out.
-    // #[test]
-    // fun flow() {
-    //     let scenario_val = ts::begin(USER_ONE);
-    //     let scenario = &mut scenario_val;
+    #[test]
+    fun flow() {
+        let mut scenario = ts::begin(USER_ONE);
 
-    //     init_tests(scenario);
-    //     let item_ids = new_bag_with_items(scenario, 2, USER_ONE, USER_TWO);
+        init_tests(&mut scenario);
+        let mut item_ids = new_bag_with_items(&mut scenario, 2, USER_ONE, USER_TWO);
 
-    //     // RECEIVER PART
-    //     ts::next_tx(scenario, USER_TWO);
+        // RECEIVER PART
+        scenario.next_tx(USER_TWO);
 
-    //     let store = ts::take_shared<BagStore>(scenario);
+        let mut store = scenario.take_shared<BagStore>();
 
-    //     let (bag, claim_proof) = zk_bag::init_claim(&mut store, ctx(scenario));
+        let (mut bag, claim_proof) = store.init_claim(scenario.ctx());
 
-    //     while(vector::length(&item_ids) > 0) {
-    //         let id = vector::pop_back(&mut item_ids);
-    //         let item: TestItem = zk_bag::claim(&mut bag, &claim_proof, id);
-    //         sui::transfer::transfer(item, USER_TWO);
-    //     };
+        while(item_ids.length() > 0) {
+            let item: TestItem = bag.claim(&claim_proof, ts::receiving_ticket_by_id(item_ids.pop_back()));
+            sui::transfer::transfer(item, USER_TWO);
+        };
 
-    //     zk_bag::finalize(bag, claim_proof);
+        bag.finalize(claim_proof);
 
-    //     ts::return_shared(store);
+        ts::return_shared(store);
 
-    //     ts::end(scenario_val);
-    // }
+        scenario.end();
+    }
 
-    #[test, expected_failure(abort_code= zk_bag::zk_bag::ETooManyItems)]
+    #[test, expected_failure(abort_code= ::zk_bag::zk_bag::ETooManyItems)]
     fun too_many_items(){
-        let scenario_val = ts::begin(USER_ONE);
+        let mut scenario_val = ts::begin(USER_ONE);
         let scenario = &mut scenario_val;
 
         init_tests(scenario);
@@ -60,37 +52,37 @@ module zk_bag::zk_bag_tests {
         abort 1337
     }
 
-    #[test, expected_failure(abort_code= zk_bag::zk_bag::EUnauthorized)]
+    #[test, expected_failure(abort_code= ::zk_bag::zk_bag::EUnauthorized)]
     fun unauthorized_access(){
-        let scenario_val = ts::begin(USER_ONE);
+        let mut scenario_val = ts::begin(USER_ONE);
         let scenario = &mut scenario_val;
 
         init_tests(scenario);
         new_bag_with_items(scenario, 2, USER_ONE, USER_TWO);
         
-        ts::next_tx(scenario, USER_THREE);
-        let store = ts::take_shared<BagStore>(scenario);
-        let (_bag, _claim) = zk_bag::reclaim(&mut store, USER_TWO, ctx(scenario));
+        scenario.next_tx(USER_THREE);
+        let mut store = scenario.take_shared<BagStore>();
+        let (_bag, _claim) = store.reclaim(USER_TWO, scenario.ctx());
 
         abort 1337
     }
 
-    #[test, expected_failure(abort_code= zk_bag::zk_bag::EClaimAddressNotExists)]
+    #[test, expected_failure(abort_code= ::zk_bag::zk_bag::EClaimAddressNotExists)]
     fun tries_to_claim_non_existing_bag() {
-        let scenario_val = ts::begin(USER_ONE);
+        let mut scenario_val = ts::begin(USER_ONE);
         let scenario = &mut scenario_val;
 
         init_tests(scenario);
-        ts::next_tx(scenario, USER_THREE);
-        let store = ts::take_shared<BagStore>(scenario);
-        let (_bag, _claim) = zk_bag::init_claim(&mut store, ctx(scenario));
+        scenario.next_tx(USER_THREE);
+        let mut store = scenario.take_shared<BagStore>();
+        let (_bag, _claim) = store.init_claim(scenario.ctx());
 
         abort 1337
     }
 
-    #[test, expected_failure(abort_code= zk_bag::zk_bag::EClaimAddressAlreadyExists)]
+    #[test, expected_failure(abort_code= ::zk_bag::zk_bag::EClaimAddressAlreadyExists)]
     fun bag_already_exists() {
-        let scenario_val = ts::begin(USER_ONE);
+        let mut scenario_val = ts::begin(USER_ONE);
         let scenario = &mut scenario_val;
 
         init_tests(scenario);
@@ -100,162 +92,170 @@ module zk_bag::zk_bag_tests {
         abort 1337
     }
 
-    #[test, expected_failure(abort_code= zk_bag::zk_bag::EBagNotEmpty)]
+    #[test, expected_failure(abort_code= ::zk_bag::zk_bag::EBagNotEmpty)]
     fun try_to_finalize_non_empty_bag(){
-        let scenario_val = ts::begin(USER_ONE);
+        let mut scenario_val = ts::begin(USER_ONE);
         let scenario = &mut scenario_val;
 
         init_tests(scenario);
         new_bag_with_items(scenario, 2, USER_ONE, USER_TWO);
         
-        ts::next_tx(scenario, USER_TWO);
-        let store = ts::take_shared<BagStore>(scenario);
-        let (bag, claim_proof) = zk_bag::init_claim(&mut store, ctx(scenario));
-        zk_bag::finalize(bag, claim_proof);
+        scenario.next_tx(USER_TWO);
+        let mut store = scenario.take_shared<BagStore>();
+        let (bag, claim_proof) = store.init_claim(scenario.ctx());
+        bag.finalize(claim_proof);
 
         abort 1337
     }
 
-    // #[test, expected_failure(abort_code= zk_bag::zk_bag::EItemNotExists)]
-    // fun tries_to_claim_non_existing_id(){
-    //     let scenario_val = ts::begin(USER_ONE);
-    //     let scenario = &mut scenario_val;
+    #[test, expected_failure(abort_code= ::zk_bag::zk_bag::EItemNotExists)]
+    fun tries_to_claim_non_existing_id(){
+        let mut scenario_val = ts::begin(USER_ONE);
+        let scenario = &mut scenario_val;
 
-    //     init_tests(scenario);
-    //     new_bag_with_items(scenario, 2, USER_ONE, USER_TWO);
+        init_tests(scenario);
+        let _ = new_bag_with_items(scenario, 2, USER_ONE, USER_TWO);
+
+        let random_item = TestItem {
+            id: object::new(scenario.ctx())
+        };
+
+        let random_item_id = object::id(&random_item);
         
-    //     ts::next_tx(scenario, USER_TWO);
-    //     let store = ts::take_shared<BagStore>(scenario);
-    //     let (bag, claim_proof) = zk_bag::init_claim(&mut store, USER_TWO, ctx(scenario));
+        scenario.next_tx(USER_TWO);
+        let mut store = scenario.take_shared<BagStore>();
 
-    //     // tries to claim using an id that does not exist on the object.
-    //     let _item: TestItem = zk_bag::claim(&mut bag, &claim_proof, 2);
+        let (mut bag, claim_proof) = store.init_claim(scenario.ctx());
+        sui::transfer::public_transfer(random_item, object::id_address(&bag));
 
-    //     abort 1337
-    // }
+        scenario.next_tx(USER_TWO);
 
-    // #[test, expected_failure(abort_code= zk_bag::zk_bag::EUnauthorizedProof)]
-    // fun try_to_claim_with_invalid_proof(){
-    //     let scenario_val = ts::begin(USER_ONE);
-    //     let scenario = &mut scenario_val;
+        // tries to claim using an id that does not exist on the object.
+        let _item: TestItem = bag.claim(&claim_proof, ts::receiving_ticket_by_id(random_item_id));
 
-    //     init_tests(scenario);
-    //     new_bag_with_items(scenario, 2, USER_ONE, USER_TWO);
-    //     new_bag_with_items(scenario, 2, USER_ONE, USER_THREE);
+        abort 1337
+    }
+
+    #[test, expected_failure(abort_code= ::zk_bag::zk_bag::EUnauthorizedProof)]
+    fun try_to_claim_with_invalid_proof(){
+        let mut scenario_val = ts::begin(USER_ONE);
+        let scenario = &mut scenario_val;
+
+        init_tests(scenario);
+        let mut item_ids = new_bag_with_items(scenario, 2, USER_ONE, USER_TWO);
+        new_bag_with_items(scenario, 2, USER_ONE, USER_THREE);
         
-    //     ts::next_tx(scenario, USER_ONE);
-    //     let store = ts::take_shared<BagStore>(scenario);
-    //     let (bag, _claim_proof) = zk_bag::init_claim(&mut store, USER_TWO, ctx(scenario));
-    //     let (_bag_two, claim_proof_two) = zk_bag::init_claim(&mut store, USER_THREE, ctx(scenario));
+        scenario.next_tx(USER_ONE);
+        let mut store = scenario.take_shared<BagStore>();
+        let (mut bag, _claim_proof) = store.reclaim(USER_TWO, scenario.ctx());
+        let (_bag_two, claim_proof_two) = store.reclaim(USER_THREE, scenario.ctx());
 
-    //     let _item: TestItem = zk_bag::claim(&mut bag, &claim_proof_two, 0);
+        let _item: TestItem = bag.claim(&claim_proof_two, ts::receiving_ticket_by_id(vector::pop_back(&mut item_ids)));
 
-    //     abort 1337
-    // }
+        abort 1337
+    }
 
-    #[test, expected_failure(abort_code= zk_bag::zk_bag::EUnauthorizedProof)]
+    #[test, expected_failure(abort_code= ::zk_bag::zk_bag::EUnauthorizedProof)]
     fun try_to_finalize_with_invalid_proof(){
-        let scenario_val = ts::begin(USER_ONE);
+        let mut scenario_val = ts::begin(USER_ONE);
         let scenario = &mut scenario_val;
 
         init_tests(scenario);
         new_bag_with_items(scenario, 2, USER_ONE, USER_TWO);
         new_bag_with_items(scenario, 2, USER_ONE, USER_THREE);
         
-        ts::next_tx(scenario, USER_TWO);
-        let store = ts::take_shared<BagStore>(scenario);
+        scenario.next_tx(USER_TWO);
+        let mut store = scenario.take_shared<BagStore>();
 
-        let (bag, _claim_proof) = zk_bag::init_claim(&mut store, ctx(scenario));
+        let (bag, _claim_proof) = store.init_claim(scenario.ctx());
 
-        ts::next_tx(scenario, USER_THREE);
-        let (_bag_two, claim_proof_two) = zk_bag::init_claim(&mut store, ctx(scenario));
+        scenario.next_tx(USER_THREE);
+        let (_bag_two, claim_proof_two) = store.init_claim(scenario.ctx());
 
-        zk_bag::finalize(bag, claim_proof_two);
+        bag.finalize(claim_proof_two);
 
         abort 1337
     }
 
    #[test]
     fun switch_receiver_successfully() {
-        let scenario_val = ts::begin(USER_ONE);
-        let scenario = &mut scenario_val;
+        let mut scenario = ts::begin(USER_ONE);
 
-        init_tests(scenario);
-        new_bag_with_items(scenario, 1, USER_ONE, USER_TWO);
+        init_tests(&mut scenario);
+        new_bag_with_items(&mut scenario, 1, USER_ONE, USER_TWO);
         
-        ts::next_tx(scenario, USER_ONE);
-        let store = ts::take_shared<BagStore>(scenario);
-        zk_bag::update_receiver(&mut store, USER_TWO, USER_THREE, ctx(scenario));
+        scenario.next_tx(USER_ONE);
+        let mut store = scenario.take_shared<BagStore>();
+        store.update_receiver(USER_TWO, USER_THREE, scenario.ctx());
 
         ts::return_shared(store);
-        ts::end(scenario_val);
+        scenario.end();
     }
 
-    #[test, expected_failure(abort_code= zk_bag::zk_bag::EUnauthorized)]
+    #[test, expected_failure(abort_code= ::zk_bag::zk_bag::EUnauthorized)]
     fun non_owner_tries_to_switch_recipient() {
-        let scenario_val = ts::begin(USER_ONE);
-        let scenario = &mut scenario_val;
+        let mut scenario = ts::begin(USER_ONE);
 
-        init_tests(scenario);
-        new_bag_with_items(scenario, 1, USER_ONE, USER_TWO);
+        init_tests(&mut scenario);
+        new_bag_with_items(&mut scenario, 1, USER_ONE, USER_TWO);
         
-        ts::next_tx(scenario, USER_TWO);
-        let store = ts::take_shared<BagStore>(scenario);
-        zk_bag::update_receiver(&mut store, USER_TWO, USER_THREE, ctx(scenario));
+        scenario.next_tx(USER_TWO);
+        let mut store = scenario.take_shared<BagStore>();
+        store.update_receiver(USER_TWO, USER_THREE, scenario.ctx());
 
         ts::return_shared(store);
-        ts::end(scenario_val);
+        scenario.end();
     }
 
-    #[test, expected_failure(abort_code= zk_bag::zk_bag::EClaimAddressNotExists)]
+    #[test, expected_failure(abort_code= ::zk_bag::zk_bag::EClaimAddressNotExists)]
     fun tries_to_switch_non_existing_address() {
-        let scenario_val = ts::begin(USER_ONE);
+        let mut scenario_val = ts::begin(USER_ONE);
         let scenario = &mut scenario_val;
 
         init_tests(scenario);
 
-        ts::next_tx(scenario, USER_TWO);
-        let store = ts::take_shared<BagStore>(scenario);
-        zk_bag::update_receiver(&mut store, USER_THREE, USER_TWO, ctx(scenario));
+        scenario.next_tx(USER_TWO);
+        let mut store = scenario.take_shared<BagStore>();
+        store.update_receiver(USER_THREE, USER_TWO, scenario.ctx());
 
         abort 1337
     }
 
-    #[test, expected_failure(abort_code= zk_bag::zk_bag::EClaimAddressAlreadyExists)]
+    #[test, expected_failure(abort_code= ::zk_bag::zk_bag::EClaimAddressAlreadyExists)]
     fun tries_to_switch_to_address_that_already_has_bag() {
-        let scenario_val = ts::begin(USER_ONE);
+        let mut scenario_val = ts::begin(USER_ONE);
         let scenario = &mut scenario_val;
 
         init_tests(scenario);
         new_bag_with_items(scenario, 1, USER_ONE, USER_TWO);
         new_bag_with_items(scenario, 1, USER_ONE, USER_THREE);
 
-        ts::next_tx(scenario, USER_TWO);
-        let store = ts::take_shared<BagStore>(scenario);
-        zk_bag::update_receiver(&mut store, USER_TWO, USER_THREE, ctx(scenario));
+        scenario.next_tx(USER_TWO);
+        let mut store = scenario.take_shared<BagStore>();
+        store.update_receiver(USER_TWO, USER_THREE, scenario.ctx());
 
         abort 1337
     }
 
 
     fun init_tests(scenario: &mut Scenario) {
-        ts::next_tx(scenario, USER_ONE);
-        zk_bag::init_for_testing(ctx(scenario))
+        scenario.next_tx(USER_ONE);
+        zk_bag::init_for_testing(scenario.ctx())
     }
 
-    fun new_bag_with_items(scenario: &mut Scenario, item_count: u8, sender: address, recipient: address): vector<address> {
-        ts::next_tx(scenario, sender);
-        let store = ts::take_shared<BagStore>(scenario);
+    fun new_bag_with_items(scenario: &mut Scenario, item_count: u8, sender: address, recipient: address): vector<ID> {
+        scenario.next_tx(sender);
+        let mut store = scenario.take_shared<BagStore>();
 
-        let addresses: vector<address> = vector::empty();
+        let mut addresses: vector<ID> = vector[];
 
-        zk_bag::new(&mut store, recipient, ctx(scenario));
+        store.new(recipient, scenario.ctx());
 
-        let i: u8 = 0;
+        let mut i: u8 = 0;
         while(i < item_count){
-            let item = new_item(ctx(scenario));
-            vector::push_back(&mut addresses, object::id_address(&item));
-            zk_bag::add(&mut store, recipient, item, ctx(scenario));
+            let item = new_item(scenario.ctx());
+            addresses.push_back(object::id(&item));
+            store.add(recipient, item, scenario.ctx());
             i = i + 1;
         };
 


### PR DESCRIPTION
Now that tests for `Receiving` work in the release, I enabled all tests & migrated the code to move2024.